### PR TITLE
Enhance High Level Assembler Highlighting

### DIFF
--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -126,8 +126,15 @@
 							"_description": "This group refers to an instruction operator",
 							"name": "keyword.control.hlasm",
 							"patterns": [
-								{"include": "#operators"},
-								{"include": "#numbers"}
+								{
+									"include": "#asmSpecialStatements"
+								},
+								{
+									"include": "#operators"
+								},
+								{
+									"include": "#numbers"
+								}
 							]
 						},
 						"2": {
@@ -150,9 +157,15 @@
 							"_description": "This group refers to an instruction operator",
 							"name": "keyword.control.hlasm",
 							"patterns": [
-								{"include": "#operators"},
-								{"include": "#numbers"}
-								
+								{
+									"include": "#asmSpecialStatements"
+								},
+								{
+									"include": "#operators"
+								},
+								{
+									"include": "#numbers"
+								}
 							]
 						},
 						"2": {
@@ -177,6 +190,11 @@
 			"_description": "marks numbers properly",
 			"match": "(?<=[=(),*\\s])-?\\d*(?=[=(),*\\s]|$)",
 			"name": "constant.numeric.hlasm"
+		},
+		"asmSpecialStatements": {
+			"_description": "allows for special assembler statements",
+			"match": "(?<=[=(),*\\s])=?\\d*(A|B|C|D|E|F|G|H|V|X|Z)(L\\d*)?(?=[=(),*\\s]|$)",
+			"name": "support.type.hlasm"
 		}
 	},
 	"scopeName": "source.hlasm"

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -2,68 +2,136 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "IBM HLASM",
 	"patterns": [
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#strings"
-		}
+		{"include": "#hlasm_syntax"}
 	],
 	"repository": {
-		"keywords": {
-			"_description": "The pattern order is important.",
+		"hlasm_syntax": {
+				"patterns": [
+					{
+						"include": "#lineComment"
+					},
+					{
+						"include": "#continuation"
+					},
+					{
+						"include": "#asmLine"
+					}
+				]
+		},
+		"lineComment": {
+			"_description": "All statements that have a * in column 1",
 			"patterns": [
 				{
-					"_description": "'*PROCESS' that begins in column 1 and anything that follows",
-					"name": "keyword.other.hlasm",
-					"match": "^\\*PROCESS\\s+.*$"
-				},
-				{
-					"_description": "All statements that have a * in column 1",
 					"name": "comment.line.double-slash.hlasm",
-					"match": "(^|\\n)\\*.*"
-				},
+					"match": "^\\*.*$"
+				}
+			]
+		},
+		"continuation": {
+			"_description": "Continuation character that appears in column 72",
+			"patterns": [
 				{
-					"_description": "Continuation character that appears in column 72",
-					"match": "(^|\\n).{71,71}(.)",
+					"match": "^(.{71,71})(.)$",
 					"captures": {
+						"1": {
+							"_description": "Allow syntax hilighting of the rest of the line",
+							"patterns": [
+								{"include": "#asmLine"}
+							]
+						},
 						"2": {
 							"name": "keyword.other.hlasm"
-						}
-					}
-				},
-				{
-					"_description": "Reserved words",
-					"match": "\\b(DROP|USING|TITLE|EJECT|SYSSTATE|END|CSECT|RSECT|AMODE|RMODE)\\b",
-					"name": "keyword.operator.hlasm"
-				},
-				{
-					"_description": "Comments that appear after a label (optional) and instruction and operands",
-					"match": "(^|\\n)([^*]\\S*|\\s*)(\\s+(\\S+)\\s+(\\S+))(.*)",
-					"captures": {
-						"4": {
-							"name": "keyword.other.hlasm"
-						},
-						"5": {
-							"name": "keyword.control.hlasm"
-						},
-						"6": {
-							"name": "comment.line.double-slash.hlasm"
 						}
 					}
 				}
 			]
 		},
-		"strings": {
-			"_description": "",
+		"asmLine": {
+			"_description": "The various parts of an assembler line",
 			"patterns": [
 				{
-					"match": "(^|\\n).*('.*')",
+					"match": "^([^*]\\S*)?\\s+(.*)$",
 					"captures": {
+						"1": {
+							"_description": "The label for a line.",
+							"name": "entity.name.function.hlasm"
+						},
 						"2": {
-							"name": "string.quoted.single.hlasm"
+							"_description": "The assembler instructions for this statement",
+							"patterns": [
+								{"include": "#asmStatement"}
+							]
 						}
 					}
+				}
+			]
+		},
+		"asmStatement": {
+			"_description": "An assembler source code statement",
+			"patterns": [
+				{
+					"include": "#asmInstruction"
+				}
+			]
+		},
+		"asmInstruction": {
+			"_description": "A simple assembler source statement with 3 things. An instruction, parameters, and comment",
+			"patterns": [
+				{
+					"match": "(\\S+)\\s+(.*)",
+					"captures": {
+						"1": {
+							"name": "keyword.other.hlasm"
+						},
+						"2": {
+							"patterns": [
+								{"include": "#asmInstructionArguments"}
+							]
+						}
+					}
+				}
+			]
+		},
+		"asmInstructionArguments": {
+			"patterns": [
+				{
+					"_description": "Handle strings in an instruction",
+					"match": "(\\S*)('.*')(.*)",
+					"captures": {
+						"1": {
+							"_description": "This group refers to an instruction operator",
+							"name": "keyword.control.hlasm"
+						},
+						"2": {
+							"_description": "A string was found, so we can't be sure this is the end of the line",
+							"name": "string.quoted.single.hlasm"
+						},
+						"3": {
+							"_description": "Recursively call this rule to get all patterns.",
+							"patterns": [
+								{"include": "#asmInstructionArguments"}
+							]
+						}
+					}
+				},
+				{
+					"_description": "Handle no strings in instruction",
+					"match": "(\\S*)(.*)",
+					"captures": {
+						"1": {
+							"_description": "This group refers to an instruction operator",
+							"name": "keyword.control.hlasm"
+						},
+						"2": {
+							"_description": "The rest of the line is a comment.",
+							"name": "comment.line.double-slash.hlasm"
+						}
+					}
+				},
+				{
+					"_description": "If the current pattern starts with a space, then we should comment the rest of the string",
+					"match": "\\s.*",
+					"name": "comment.line.double-slash"
 				}
 			]
 		}

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -17,6 +17,9 @@
 						"include": "#continuation"
 					},
 					{
+						"include": "#asmArgumentLine"
+					},
+					{
 						"include": "#asmLineStart"
 					}
 				]
@@ -48,6 +51,7 @@
 						"1": {
 							"_description": "Allow syntax hilighting of the rest of the line",
 							"patterns": [
+								{"include": "#asmArgumentLine"},
 								{"include": "#asmLineStart"}
 							]
 						},
@@ -96,6 +100,22 @@
 				}
 			]
 		},
+		"asmArgumentLine": {
+			"_description": "This is for a line consisting of only an argument. This implies the previous line was a continuation",
+			"patterns": [
+				{
+					"_description": "A line matching this syntax should follow the argument syntax",
+					"match": "^\\s+(\\S+=.*)$",
+					"captures": {
+						"1": {
+							"patterns": [
+								{"include": "#asmArguments"}
+							]
+						}
+					}
+				}
+			]
+		},
 		"asmArguments": {
 			"patterns": [
 				{
@@ -104,7 +124,11 @@
 					"captures": {
 						"1": {
 							"_description": "This group refers to an instruction operator",
-							"name": "keyword.control.hlasm"
+							"name": "keyword.control.hlasm",
+							"patterns": [
+								{"include": "#operators"},
+								{"include": "#numbers"}
+							]
 						},
 						"2": {
 							"_description": "A string was found, so we can't be sure this is the end of the line",
@@ -124,7 +148,12 @@
 					"captures": {
 						"1": {
 							"_description": "This group refers to an instruction operator",
-							"name": "keyword.control.hlasm"
+							"name": "keyword.control.hlasm",
+							"patterns": [
+								{"include": "#operators"},
+								{"include": "#numbers"}
+								
+							]
 						},
 						"2": {
 							"_description": "The rest of the line is a comment.",
@@ -135,9 +164,19 @@
 				{
 					"_description": "If the current pattern starts with a space, then we should comment the rest of the string",
 					"match": "\\s.*",
-					"name": "comment.line.double-slash"
+					"name": "comment.line.double-slash.hlasm"
 				}
 			]
+		},
+		"operators": {
+			"_description": "marks operators properly",
+			"match": "[=(),*]",
+			"name": "keyword.operator.hlasm"
+		},
+		"numbers": {
+			"_description": "marks numbers properly",
+			"match": "(?<=[=(),*\\s])-?\\d*(?=[=(),*\\s])",
+			"name": "constant.numeric.hlasm"
 		}
 	},
 	"scopeName": "source.hlasm"

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -17,7 +17,7 @@
 						"include": "#continuation"
 					},
 					{
-						"include": "#asmLine"
+						"include": "#asmLineStart"
 					}
 				]
 		},
@@ -48,7 +48,7 @@
 						"1": {
 							"_description": "Allow syntax hilighting of the rest of the line",
 							"patterns": [
-								{"include": "#asmLine"}
+								{"include": "#asmLineStart"}
 							]
 						},
 						"2": {
@@ -58,7 +58,7 @@
 				}
 			]
 		},
-		"asmLine": {
+		"asmLineStart": {
 			"_description": "The various parts of an assembler line",
 			"patterns": [
 				{
@@ -71,18 +71,10 @@
 						"2": {
 							"_description": "The assembler instructions for this statement",
 							"patterns": [
-								{"include": "#asmStatement"}
+								{"include": "#asmInstruction"}
 							]
 						}
 					}
-				}
-			]
-		},
-		"asmStatement": {
-			"_description": "An assembler source code statement",
-			"patterns": [
-				{
-					"include": "#asmInstruction"
 				}
 			]
 		},
@@ -90,21 +82,21 @@
 			"_description": "A simple assembler source statement with 3 things. An instruction, parameters, and comment",
 			"patterns": [
 				{
-					"match": "(\\S+)\\s+(.*)",
+					"match": "(\\S+)\\s*(.*)",
 					"captures": {
 						"1": {
 							"name": "keyword.other.hlasm"
 						},
 						"2": {
 							"patterns": [
-								{"include": "#asmInstructionArguments"}
+								{"include": "#asmArguments"}
 							]
 						}
 					}
 				}
 			]
 		},
-		"asmInstructionArguments": {
+		"asmArguments": {
 			"patterns": [
 				{
 					"_description": "Handle strings in an instruction",
@@ -121,7 +113,7 @@
 						"3": {
 							"_description": "Recursively call this rule to get all patterns.",
 							"patterns": [
-								{"include": "#asmInstructionArguments"}
+								{"include": "#asmArguments"}
 							]
 						}
 					}

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -175,7 +175,7 @@
 		},
 		"numbers": {
 			"_description": "marks numbers properly",
-			"match": "(?<=[=(),*\\s])-?\\d*(?=[=(),*\\s])",
+			"match": "(?<=[=(),*\\s])-?\\d*(?=[=(),*\\s]|$)",
 			"name": "constant.numeric.hlasm"
 		}
 	},

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -8,6 +8,9 @@
 		"hlasm_syntax": {
 				"patterns": [
 					{
+						"include": "#lineTooLong"
+					},
+					{
 						"include": "#lineComment"
 					},
 					{
@@ -17,6 +20,15 @@
 						"include": "#asmLine"
 					}
 				]
+		},
+		"lineTooLong": {
+			"_description": "Assembler lines should only be 72 chars, at 73 the entire line should be in error",
+			"patterns": [
+				{
+					"name": "invalid.illegal.hlasm",
+					"match": "^.{73,}"  
+				}
+			]
 		},
 		"lineComment": {
 			"_description": "All statements that have a * in column 1",


### PR DESCRIPTION
I've added some fixes to syntax highlighting.

* Storage specifications such as `CL133` and `0D` are highlighted as a `support.type`
* Numbers are highlighted as `constant.numeric`
* If a line exceeds 72 characters, it will be highlighted as red.
  * Not sure if HLASM can be any different than 71 cols with 72 being a continuation
* Fixed some issues with continuation character highlighting
* Fixed some random syntax highlighting issues, (invalid colors, broken syntax, etc.)
* Line labels are now marked as a `entity.name.function` to make them stand out a bit from other elements in the assembler output. I chose function because labels can be branched to (if I remember correctly) which means you could think of them as a function.
* STRING PROCESSING!!!!

I think that's everything. Let me know if you have any questions or required changes.