### PR TITLE
New line numbers

### DIFF
--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -47,7 +47,7 @@
 			"patterns": [
 				{
 					"name": "invalid.illegal.hlasm",
-					"match": "^.{73,}"
+					"match": "^.{81,}"
 				}
 			]
 		},
@@ -64,7 +64,7 @@
 			"_description": "Continuation character that appears in column 72",
 			"patterns": [
 				{
-					"match": "^(.{71,71})(.)$",
+					"match": "^(.{71,71})(.)(.{0,8})$",
 					"captures": {
 						"1": {
 							"_description": "Allow syntax highlighting of the rest of the line",
@@ -79,6 +79,10 @@
 						},
 						"2": {
 							"name": "keyword.other.hlasm"
+						},
+						"3": {
+							"_description": "SEQUENCE NUMBERS!!!!!",
+							"name": "constant.numeric.hlasm"
 						}
 					}
 				}

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -29,6 +29,9 @@
 		"additionalAsmHighlight": {
 			"patterns": [
 				{
+					"include": "#labels"
+				},
+				{
 					"include": "#asmSpecialStatements"
 				},
 				{
@@ -64,7 +67,7 @@
 					"match": "^(.{71,71})(.)$",
 					"captures": {
 						"1": {
-							"_description": "Allow syntax hilighting of the rest of the line",
+							"_description": "Allow syntax highlighting of the rest of the line",
 							"patterns": [
 								{
 									"include": "#asmArgumentLine"
@@ -223,19 +226,24 @@
 				}
 			]
 		},
+		"labels": {
+			"_description": "marks special labels in the code",
+			"match": "[*]",
+			"name": "support.function.hlasm"
+		},
 		"operators": {
 			"_description": "marks operators properly",
-			"match": "[=(),*]",
+			"match": "[=(),+]",
 			"name": "keyword.operator.hlasm"
 		},
 		"numbers": {
 			"_description": "marks numbers properly",
-			"match": "(?<=[=(),*\\s])-?\\d*(?=[=(),*\\s]|$)",
+			"match": "(?<=[=(),*\\s+])-?\\d*(?=[=(),*+\\s]|$)",
 			"name": "constant.numeric.hlasm"
 		},
 		"asmSpecialStatements": {
 			"_description": "allows for special assembler statements",
-			"match": "(?<=[=(),*\\s])=?\\d*(A|B|C|D|E|F|G|H|V|X|Z)(L\\d*)?(?=[=(),*\\s]|$)",
+			"match": "(?<=[=(),*+\\s])=?\\d*(A|B|C|D|E|F|G|H|V|X|Z)(L\\d*)?(?=[=(),*\\s+]|$)",
 			"name": "support.type.hlasm"
 		}
 	},

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -24,6 +24,18 @@
 					}
 				]
 		},
+		"additionalAsmHighlight": {
+			"patterns": [{
+				"include": "#asmSpecialStatements"
+			},
+			{
+				"include": "#operators"
+			},
+			{
+				"include": "#numbers"
+			}
+]
+		},
 		"lineTooLong": {
 			"_description": "Assembler lines should only be 72 chars, at 73 the entire line should be in error",
 			"patterns": [
@@ -119,6 +131,33 @@
 		"asmArguments": {
 			"patterns": [
 				{
+					"_description": "Handle a length instruction",
+					"match": "(\\S*?)(L')(.*)",
+					"captures": {
+						"1": {
+							"_description": "This group refers to an instruction operator",
+							"name": "keyword.control.hlasm",
+							"patterns": [
+								{
+										"include": "#additionalAsmHighlight"
+									}
+							]
+						},
+						"2": {
+							"_description": "Highlight the L' operator as a type",
+							"name": "support.type.hlasm"
+						},
+						"3": {
+							"_description": "Recursively call this rule to get all patterns.",
+							"patterns": [
+								{
+									"include": "#asmArguments"
+								}
+							]
+						}
+					}
+				},
+				{
 					"_description": "Handle strings in an instruction",
 					"match": "(\\S*)('.*')(.*)",
 					"captures": {
@@ -127,13 +166,7 @@
 							"name": "keyword.control.hlasm",
 							"patterns": [
 								{
-									"include": "#asmSpecialStatements"
-								},
-								{
-									"include": "#operators"
-								},
-								{
-									"include": "#numbers"
+									"include": "#additionalAsmHighlight"
 								}
 							]
 						},
@@ -158,13 +191,7 @@
 							"name": "keyword.control.hlasm",
 							"patterns": [
 								{
-									"include": "#asmSpecialStatements"
-								},
-								{
-									"include": "#operators"
-								},
-								{
-									"include": "#numbers"
+									"include": "#additionalAsmHighlight"
 								}
 							]
 						},

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -16,7 +16,7 @@
 					"include": "#lineComment"
 				},
 				{
-					"include": "#continuation"
+					"include": "#parseLine"
 				},
 				{
 					"include": "#asmArgumentLine"
@@ -56,15 +56,47 @@
 			"patterns": [
 				{
 					"name": "comment.line.double-slash.hlasm",
-					"match": "^\\*.*$"
+					"match": "^(\\*.{70,70})(.*)",
+					"captures": {
+						"1": {
+							"name": "comment.line.double-slash.hlasm"
+						},
+						"2": {
+							"patterns": [
+								{
+									"match": "\\s(.{0,8})",
+									"captures": {
+										"1": {
+											"name": "constant.numeric.hlasm"
+										}
+									}
+								},
+								{
+									"match": "([^\\s])(.{0,8})",
+									"captures": {
+										"1": {
+											"name": "invalid.illegal.hlasm"
+										},
+										"2": {
+											"name": "constant.numeric.hlasm"
+										}
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"name": "comment.line.double-slash.hlasm",
+					"match": "\\*.*"
 				}
 			]
 		},
-		"continuation": {
-			"_description": "Continuation character that appears in column 72",
+		"parseLine": {
 			"patterns": [
 				{
-					"match": "^(.{71,71})(.)(.{0,8})$",
+					"_description": "Continuation character that appears in column 72",
+					"match": "^(.{71,71})([^\\s])(.{0,8})",
 					"captures": {
 						"1": {
 							"_description": "Allow syntax highlighting of the rest of the line",
@@ -79,6 +111,36 @@
 						},
 						"2": {
 							"name": "keyword.other.hlasm"
+						},
+						"3": {
+							"_description": "SEQUENCE NUMBERS!!!!!",
+							"name": "constant.numeric.hlasm"
+						},
+						"5": {
+							"_description": "This next capture group is the entire next line",
+							"patterns": [
+								{
+									"match": "\\S.*",
+									"name": "invalid.illegal"
+								}
+							]
+						}
+					}
+				},
+				{
+					"_description": "Sequence numbers for non-continuation lines",
+					"match": "^(.{71,71})(\\s?)(.{0,8})$",
+					"captures": {
+						"1": {
+							"_description": "Allow syntax highlighting of the rest of the line",
+							"patterns": [
+								{
+									"include": "#asmArgumentLine"
+								},
+								{
+									"include": "#asmLineStart"
+								}
+							]
 						},
 						"3": {
 							"_description": "SEQUENCE NUMBERS!!!!!",

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -67,7 +67,12 @@
 									"match": "\\s(.{0,8})",
 									"captures": {
 										"1": {
-											"name": "constant.numeric.hlasm"
+											"_description": "SEQUENCE NUMBERS!!!!!",
+											"patterns": [
+												{
+													"include": "#sequenceNumbers"
+												}
+											]
 										}
 									}
 								},
@@ -78,7 +83,12 @@
 											"name": "invalid.illegal.hlasm"
 										},
 										"2": {
-											"name": "constant.numeric.hlasm"
+											"_description": "SEQUENCE NUMBERS!!!!!",
+											"patterns": [
+												{
+													"include": "#sequenceNumbers"
+												}
+											]
 										}
 									}
 								}
@@ -114,7 +124,11 @@
 						},
 						"3": {
 							"_description": "SEQUENCE NUMBERS!!!!!",
-							"name": "constant.numeric.hlasm"
+							"patterns": [
+								{
+									"include": "#sequenceNumbers"
+								}
+							]
 						},
 						"5": {
 							"_description": "This next capture group is the entire next line",
@@ -144,7 +158,11 @@
 						},
 						"3": {
 							"_description": "SEQUENCE NUMBERS!!!!!",
-							"name": "constant.numeric.hlasm"
+							"patterns": [
+								{
+									"include": "#sequenceNumbers"
+								}
+							]
 						}
 					}
 				}
@@ -311,6 +329,10 @@
 			"_description": "allows for special assembler statements",
 			"match": "(?<=[=(),*+\\s])=?\\d*(A|B|C|D|E|F|G|H|V|X|Z)(L\\d*)?(?=[=(),*\\s+]|$)",
 			"name": "support.type.hlasm"
+		},
+		"sequenceNumbers": {
+			"name": "constant.numeric.hlasm",
+			"match": ".*"
 		}
 	},
 	"scopeName": "source.hlasm"

--- a/syntaxes/hlasm.tmLanguage.json
+++ b/syntaxes/hlasm.tmLanguage.json
@@ -2,46 +2,49 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "IBM HLASM",
 	"patterns": [
-		{"include": "#hlasm_syntax"}
+		{
+			"include": "#hlasm_syntax"
+		}
 	],
 	"repository": {
 		"hlasm_syntax": {
-				"patterns": [
-					{
-						"include": "#lineTooLong"
-					},
-					{
-						"include": "#lineComment"
-					},
-					{
-						"include": "#continuation"
-					},
-					{
-						"include": "#asmArgumentLine"
-					},
-					{
-						"include": "#asmLineStart"
-					}
-				]
+			"patterns": [
+				{
+					"include": "#lineTooLong"
+				},
+				{
+					"include": "#lineComment"
+				},
+				{
+					"include": "#continuation"
+				},
+				{
+					"include": "#asmArgumentLine"
+				},
+				{
+					"include": "#asmLineStart"
+				}
+			]
 		},
 		"additionalAsmHighlight": {
-			"patterns": [{
-				"include": "#asmSpecialStatements"
-			},
-			{
-				"include": "#operators"
-			},
-			{
-				"include": "#numbers"
-			}
-]
+			"patterns": [
+				{
+					"include": "#asmSpecialStatements"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"include": "#numbers"
+				}
+			]
 		},
 		"lineTooLong": {
 			"_description": "Assembler lines should only be 72 chars, at 73 the entire line should be in error",
 			"patterns": [
 				{
 					"name": "invalid.illegal.hlasm",
-					"match": "^.{73,}"  
+					"match": "^.{73,}"
 				}
 			]
 		},
@@ -63,8 +66,12 @@
 						"1": {
 							"_description": "Allow syntax hilighting of the rest of the line",
 							"patterns": [
-								{"include": "#asmArgumentLine"},
-								{"include": "#asmLineStart"}
+								{
+									"include": "#asmArgumentLine"
+								},
+								{
+									"include": "#asmLineStart"
+								}
 							]
 						},
 						"2": {
@@ -87,7 +94,9 @@
 						"2": {
 							"_description": "The assembler instructions for this statement",
 							"patterns": [
-								{"include": "#asmInstruction"}
+								{
+									"include": "#asmInstruction"
+								}
 							]
 						}
 					}
@@ -105,7 +114,9 @@
 						},
 						"2": {
 							"patterns": [
-								{"include": "#asmArguments"}
+								{
+									"include": "#asmArguments"
+								}
 							]
 						}
 					}
@@ -121,7 +132,9 @@
 					"captures": {
 						"1": {
 							"patterns": [
-								{"include": "#asmArguments"}
+								{
+									"include": "#asmArguments"
+								}
 							]
 						}
 					}
@@ -139,8 +152,8 @@
 							"name": "keyword.control.hlasm",
 							"patterns": [
 								{
-										"include": "#additionalAsmHighlight"
-									}
+									"include": "#additionalAsmHighlight"
+								}
 							]
 						},
 						"2": {
@@ -177,7 +190,9 @@
 						"3": {
 							"_description": "Recursively call this rule to get all patterns.",
 							"patterns": [
-								{"include": "#asmArguments"}
+								{
+									"include": "#asmArguments"
+								}
 							]
 						}
 					}


### PR DESCRIPTION
This PR adds sequence numbers as a supported highlight. It now handles the following conditions:

* `*` is now interpreted as a label highlight
* `*` lines will display as comments. Column 72 will be illegal and cols 73-80 will be sequence numbers
* Invalid line length now moved to column 81
* Sequence numbers supported after all lines now (let me know if I missed any).

PR #3 also includes some attempts to fix continuation statements. This PR does not accomplish that, I will be doing that in a separate PR.

This PR also depends on #7 to be merged into master.