### PR TITLE
Remove scheme, adjust array checks

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -37,8 +37,8 @@ export function activate(context: ExtensionContext) {
 
     // Options to control the language client
     let clientOptions: LanguageClientOptions = {
-        // Register the server for plain text documents
-        documentSelector: [{ scheme: 'file', language: 'hlasm' }],
+        // Register the server for IBM assembler documents
+        documentSelector: [{ language: 'hlasm' }],
         // documentSelector: [{ scheme: 'file', language: 'hlasm' }],
         synchronize: {
             // Notify the server about file changes to '.clientrc files contained in the workspace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ibm-assembler",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "displayName": "ibm-assembler",
     "description": "IBM Assembler Language Highlighter",
     "repository": "https://github.com/dkelosky/vscode-ibm-hlasm",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "keywords": [
         "z/OS",
         "s390",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -119,7 +119,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
     let problems = 0;
     const diagnostics: Diagnostic[] = [];
 
-    const lines = text.split("\n");
+    const lines = text.split(/\r?\n/);
     for (let i = 0; i < lines.length; i++) {
         if (lines[i].length > MAX_LEN) {
             problems++;
@@ -149,7 +149,7 @@ connection.onDefinition((parm) => {
         return null;
     }
 
-    const lines = document.getText().split("\n");
+    const lines = document.getText().split(/\r?\n/);
 
     connection.console.info(`Definition ${parm.position.character} on line '${lines[parm.position.line]}'`);
     connection.console.info(`There are ${symbolsCache.size} entries in cached symbols`);
@@ -255,7 +255,7 @@ connection.onDocumentSymbol((parm) => {
     connection.console.info(`Clearing symbol cache...`);
     symbolsCache.clear();
 
-    const lines = document.getText().split("\n");
+    const lines = document.getText().split(/\r?\n/);
     for (let i = 0; i < lines.length; i++) {
 
         // if space or * in column one, it's not a symbol

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -120,15 +120,15 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
     const diagnostics: Diagnostic[] = [];
 
     const lines = text.split("\n");
-    for (let i = 0; i < lines.length - 1; i++) {
-        if (lines[i].length - 1 > MAX_LEN) {
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].length > MAX_LEN) {
             problems++;
 
             const diagnostic: Diagnostic = {
                 severity: DiagnosticSeverity.Error,
                 range: {
                     start: { line: i, character: MAX_LEN },
-                    end: { line: i, character: lines[i].length - 1 },
+                    end: { line: i, character: lines[i].length },
                 },
                 message: `Exceeded ${MAX_LEN} characters`,
                 source: "hlasm"
@@ -256,7 +256,7 @@ connection.onDocumentSymbol((parm) => {
     symbolsCache.clear();
 
     const lines = document.getText().split("\n");
-    for (let i = 0; i < lines.length - 1; i++) {
+    for (let i = 0; i < lines.length; i++) {
 
         // if space or * in column one, it's not a symbol
         if (lines[i][0] !== " " && lines[i][0] !== "*") {
@@ -286,7 +286,7 @@ connection.onDocumentSymbol((parm) => {
                         uri: parm.textDocument.uri,
                         range: {
                             start: { line: i, character: 0 },
-                            end: { line: i, character: tokenizedLine[0].length - 1 }
+                            end: { line: i, character: tokenizedLine[0].length }
                         }
                     }
                 };


### PR DESCRIPTION
- Remove scheme check for document uri
- Removed some `- 1`'s from array length checks

Before changes:
![image](https://user-images.githubusercontent.com/32349430/105189257-c9490480-5b02-11eb-819c-af60a481fe46.png)

https://github.com/dkelosky/vscode-ibm-hlasm/blob/bdf4eb5f0f01b466752234b1295ce638d3109e3b/server/src/server.ts#L122-L124 https://github.com/dkelosky/vscode-ibm-hlasm/blob/bdf4eb5f0f01b466752234b1295ce638d3109e3b/server/src/server.ts#L258-L259
Line 123 is a loop through all the lines for error checking. By setting the upper bound at 1 less than the line count exclusive (or 2 less than the line count inclusive), it ends up skipping the last line. In my example, the last line checked is index 7293, or line number 7294.
Line 259 is the same, but for tokenizing. I admit, I'm not sure how to test the tokenizing like I can for error checking, but it's the same logic which will skip the last line.
Line 124 checks whether the line length - 1 is greater than the MAX_LENGTH. The line length is not an index, so you don't need to subtract 1. The effect is that the error is not triggered at 81 characters, as you can see in line 7292 in my example.

https://github.com/dkelosky/vscode-ibm-hlasm/blob/bdf4eb5f0f01b466752234b1295ce638d3109e3b/server/src/server.ts#L129-L132 https://github.com/dkelosky/vscode-ibm-hlasm/blob/bdf4eb5f0f01b466752234b1295ce638d3109e3b/server/src/server.ts#L287-L290
Line 131 shows the end of the range for the squiggly line that appears under errors. As you can see in my example in lines 7293 and 7294, it skips the last character in the line.
Line 289 is the same as line 131, but for tokenization. Again, I'm not sure how to test tokenization, but it follows the same logic of skipping the last character on the line.